### PR TITLE
バグ修正

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -19,6 +19,17 @@
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD945F6244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945F5244DC5EB0012785A /* iOSEngineerCodeCheckTests.swift */; };
 		BFD94601244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */; };
+		D431EDA7276D8DCF00BFD60A /* HttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDA6276D8DCF00BFD60A /* HttpMethod.swift */; };
+		D431EDA9276D8E1600BFD60A /* GitHubAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDA8276D8E1600BFD60A /* GitHubAPI.swift */; };
+		D431EDAB276D8E5300BFD60A /* GitHubAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDAA276D8E5300BFD60A /* GitHubAPIRequest.swift */; };
+		D431EDAD276D90FC00BFD60A /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDAC276D90FC00BFD60A /* Configuration.swift */; };
+		D431EDAF276D978300BFD60A /* GitHubAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDAE276D978300BFD60A /* GitHubAPIError.swift */; };
+		D431EDB1276D980900BFD60A /* GitHubSearchRepositories.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDB0276D980900BFD60A /* GitHubSearchRepositories.swift */; };
+		D431EDB3276D99F900BFD60A /* GitHubRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDB2276D99F900BFD60A /* GitHubRepository.swift */; };
+		D431EDB5276D9B5600BFD60A /* GitHubRepoOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDB4276D9B5600BFD60A /* GitHubRepoOwner.swift */; };
+		D431EDB7276D9C3200BFD60A /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDB6276D9C3200BFD60A /* Result.swift */; };
+		D431EDB9276DACAF00BFD60A /* GitHubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDB8276DACAF00BFD60A /* GitHubClient.swift */; };
+		D431EDBB276DADAA00BFD60A /* GitHubClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D431EDBA276DADAA00BFD60A /* GitHubClientError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +69,17 @@
 		BFD945FC244DC5EB0012785A /* iOSEngineerCodeCheckUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSEngineerCodeCheckUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSEngineerCodeCheckUITests.swift; sourceTree = "<group>"; };
 		BFD94602244DC5EC0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D431EDA6276D8DCF00BFD60A /* HttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpMethod.swift; sourceTree = "<group>"; };
+		D431EDA8276D8E1600BFD60A /* GitHubAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPI.swift; sourceTree = "<group>"; };
+		D431EDAA276D8E5300BFD60A /* GitHubAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIRequest.swift; sourceTree = "<group>"; };
+		D431EDAC276D90FC00BFD60A /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		D431EDAE276D978300BFD60A /* GitHubAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubAPIError.swift; sourceTree = "<group>"; };
+		D431EDB0276D980900BFD60A /* GitHubSearchRepositories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositories.swift; sourceTree = "<group>"; };
+		D431EDB2276D99F900BFD60A /* GitHubRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepository.swift; sourceTree = "<group>"; };
+		D431EDB4276D9B5600BFD60A /* GitHubRepoOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubRepoOwner.swift; sourceTree = "<group>"; };
+		D431EDB6276D9C3200BFD60A /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		D431EDB8276DACAF00BFD60A /* GitHubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubClient.swift; sourceTree = "<group>"; };
+		D431EDBA276DADAA00BFD60A /* GitHubClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubClientError.swift; sourceTree = "<group>"; };
 		D7DCA3E7A094B3EC2C603CEC /* Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; path = "Target Support Files/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests/Pods-iOSEngineerCodeCheck-iOSEngineerCodeCheckUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		DCD8786BD691BDEEB5701457 /* Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSEngineerCodeCheck_iOSEngineerCodeCheckUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E012C9D6329F0920061019EB /* Pods-iOSEngineerCodeCheckTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSEngineerCodeCheckTests.debug.xcconfig"; path = "Target Support Files/Pods-iOSEngineerCodeCheckTests/Pods-iOSEngineerCodeCheckTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -141,6 +163,7 @@
 		BFD945DD244DC5E80012785A /* iOSEngineerCodeCheck */ = {
 			isa = PBXGroup;
 			children = (
+				D431EDA2276D8D1500BFD60A /* APIClient */,
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* SearchRepositoryViewController.swift */,
@@ -149,6 +172,7 @@
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
 				BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */,
 				BFD945EC244DC5EB0012785A /* Info.plist */,
+				D431EDAC276D90FC00BFD60A /* Configuration.swift */,
 			);
 			path = iOSEngineerCodeCheck;
 			sourceTree = "<group>";
@@ -169,6 +193,47 @@
 				BFD94602244DC5EC0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckUITests;
+			sourceTree = "<group>";
+		};
+		D431EDA2276D8D1500BFD60A /* APIClient */ = {
+			isa = PBXGroup;
+			children = (
+				D431EDA5276D8D7A00BFD60A /* APIError */,
+				D431EDA4276D8D7000BFD60A /* Response */,
+				D431EDA3276D8D4C00BFD60A /* Request */,
+				D431EDB6276D9C3200BFD60A /* Result.swift */,
+				D431EDB8276DACAF00BFD60A /* GitHubClient.swift */,
+			);
+			path = APIClient;
+			sourceTree = "<group>";
+		};
+		D431EDA3276D8D4C00BFD60A /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				D431EDA6276D8DCF00BFD60A /* HttpMethod.swift */,
+				D431EDA8276D8E1600BFD60A /* GitHubAPI.swift */,
+				D431EDAA276D8E5300BFD60A /* GitHubAPIRequest.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		D431EDA4276D8D7000BFD60A /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				D431EDB0276D980900BFD60A /* GitHubSearchRepositories.swift */,
+				D431EDB2276D99F900BFD60A /* GitHubRepository.swift */,
+				D431EDB4276D9B5600BFD60A /* GitHubRepoOwner.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		D431EDA5276D8D7A00BFD60A /* APIError */ = {
+			isa = PBXGroup;
+			children = (
+				D431EDAE276D978300BFD60A /* GitHubAPIError.swift */,
+				D431EDBA276DADAA00BFD60A /* GitHubClientError.swift */,
+			);
+			path = APIError;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -393,9 +458,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D431EDB3276D99F900BFD60A /* GitHubRepository.swift in Sources */,
+				D431EDB7276D9C3200BFD60A /* Result.swift in Sources */,
 				BFD945E3244DC5E80012785A /* SearchRepositoryViewController.swift in Sources */,
+				D431EDB9276DACAF00BFD60A /* GitHubClient.swift in Sources */,
+				D431EDA9276D8E1600BFD60A /* GitHubAPI.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* RepositoryDetailViewController.swift in Sources */,
+				D431EDAB276D8E5300BFD60A /* GitHubAPIRequest.swift in Sources */,
+				D431EDA7276D8DCF00BFD60A /* HttpMethod.swift in Sources */,
+				D431EDB1276D980900BFD60A /* GitHubSearchRepositories.swift in Sources */,
+				D431EDBB276DADAA00BFD60A /* GitHubClientError.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				D431EDB5276D9B5600BFD60A /* GitHubRepoOwner.swift in Sources */,
+				D431EDAD276D90FC00BFD60A /* Configuration.swift in Sources */,
+				D431EDAF276D978300BFD60A /* GitHubAPIError.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -571,6 +647,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1F0840553247358E41216598 /* Pods-iOSEngineerCodeCheck.debug.xcconfig */;
 			buildSettings = {
+				API_HOST = "https://api.github.com";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
@@ -590,6 +667,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8456B7B2290ED402DE5DAE42 /* Pods-iOSEngineerCodeCheck.release.xcconfig */;
 			buildSettings = {
+				API_HOST = "https://api.github.com";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";

--- a/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
+++ b/iOSEngineerCodeCheck.xcodeproj/xcshareddata/xcschemes/iOSEngineerCodeCheck.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+               BuildableName = "iOSEngineerCodeCheck.app"
+               BlueprintName = "iOSEngineerCodeCheck"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945F0244DC5EB0012785A"
+               BuildableName = "iOSEngineerCodeCheckTests.xctest"
+               BlueprintName = "iOSEngineerCodeCheckTests"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BFD945FB244DC5EB0012785A"
+               BuildableName = "iOSEngineerCodeCheckUITests.xctest"
+               BlueprintName = "iOSEngineerCodeCheckUITests"
+               ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+            BuildableName = "iOSEngineerCodeCheck.app"
+            BlueprintName = "iOSEngineerCodeCheck"
+            ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BFD945DA244DC5E80012785A"
+            BuildableName = "iOSEngineerCodeCheck.app"
+            BlueprintName = "iOSEngineerCodeCheck"
+            ReferencedContainer = "container:iOSEngineerCodeCheck.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOSEngineerCodeCheck/APIClient/APIError/GitHubAPIError.swift
+++ b/iOSEngineerCodeCheck/APIClient/APIError/GitHubAPIError.swift
@@ -1,0 +1,12 @@
+//
+//  GitHubAPIError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubAPIError: Decodable, Error {
+}

--- a/iOSEngineerCodeCheck/APIClient/APIError/GitHubClientError.swift
+++ b/iOSEngineerCodeCheck/APIClient/APIError/GitHubClientError.swift
@@ -1,0 +1,18 @@
+//
+//  GitHubClientError.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum GitHubClientError: Error {
+    // 通信に失敗
+    case connectionError(Error)
+    // レスポンスのパースに失敗
+    case responseParseError(Error)
+    // APIからエラーレスポンスを受け取った
+    case apiError(GitHubAPIError)
+}

--- a/iOSEngineerCodeCheck/APIClient/GitHubClient.swift
+++ b/iOSEngineerCodeCheck/APIClient/GitHubClient.swift
@@ -1,0 +1,46 @@
+//
+//  GitHubClient.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+class GitHubClient {
+    private let session: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        let session = URLSession(configuration: configuration)
+        return session
+    }()
+
+    func send<Request: GitHubAPIRequest>(
+        request: Request,
+        completionHandler: @escaping(Result<Request.Response, GitHubClientError>) -> Void
+    ) {
+        let urlRequest = request.buildURLRequest()
+        let task = session.dataTask(with: urlRequest) { data, response, error in
+
+            switch (data, response, error) {
+            case (_, _, let error?):
+                completionHandler(Result(error: .connectionError(error)))
+            case (let data?, let response?, _):
+                do {
+                    let response = try request.response(from: data, urlRespose: response)
+                    completionHandler(Result(value: response))
+                } catch let error as GitHubAPIError {
+                    completionHandler(Result(error: .apiError(error)))
+                } catch {
+                    completionHandler(Result(error: .responseParseError(error)))
+                }
+            default:
+                fatalError(
+                    "Invalid response combination: \(String(describing: data)), \(String(describing: response)), \(String(describing: error))"
+                )
+            }
+        }
+
+        task.resume()
+    }
+}

--- a/iOSEngineerCodeCheck/APIClient/Request/GitHubAPI.swift
+++ b/iOSEngineerCodeCheck/APIClient/Request/GitHubAPI.swift
@@ -1,0 +1,31 @@
+//
+//  GitHubAPI.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+final class GitHubAPI {
+    /// リポジトリ検索API
+    struct GitHubSearchRepo: GitHubAPIRequest {
+        let keyword: String
+
+        typealias Response = GitHubSearchRepositories
+
+        var method: HttpMethod {
+            return .get
+        }
+        var path: String {
+            return "/search/repositories"
+        }
+        var queryItems: [URLQueryItem] {
+            return [URLQueryItem(name: "q", value: keyword)]
+        }
+        var headers: [String: String] {
+            return [:]
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/APIClient/Request/GitHubAPIRequest.swift
+++ b/iOSEngineerCodeCheck/APIClient/Request/GitHubAPIRequest.swift
@@ -1,0 +1,54 @@
+//
+//  GitHubAPIRequest.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+protocol GitHubAPIRequest {
+    associatedtype Response: Decodable
+
+    var baseURL: URL { get }
+    var path: String { get }
+    var method: HttpMethod { get }
+    var queryItems: [URLQueryItem] { get }
+    var headers: [String: String] { get }
+}
+
+extension GitHubAPIRequest {
+    var baseURL: URL {
+        return URL(string: Configuration.shared.apiHost)!
+    }
+
+    func buildURLRequest() -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+
+        switch method {
+        case .get:
+            components?.queryItems = queryItems
+        }
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.url = components?.url
+        urlRequest.httpMethod = method.rawValue
+        headers.forEach { key, value in
+            urlRequest.addValue(value, forHTTPHeaderField: key)
+        }
+
+        return urlRequest
+    }
+
+    func response(from data: Data, urlRespose: URLResponse) throws -> Response {
+        let decoder = JSONDecoder()
+
+        if case (200..<300)? = (urlRespose as? HTTPURLResponse)?.statusCode {
+            return try decoder.decode(Response.self, from: data)
+        } else {
+            throw try decoder.decode(GitHubAPIError.self, from: data)
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/APIClient/Request/HttpMethod.swift
+++ b/iOSEngineerCodeCheck/APIClient/Request/HttpMethod.swift
@@ -1,0 +1,13 @@
+//
+//  HttpMethod.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum HttpMethod: String {
+    case get = "GET"
+}

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubRepoOwner.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubRepoOwner.swift
@@ -9,5 +9,9 @@
 import Foundation
 
 struct GitHubRepoOwner: Decodable {
-    let avatarURL: String
+    let avatarURL: String?
+
+    enum CodingKeys: String, CodingKey {
+        case avatarURL = "avatar_url"
+    }
 }

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubRepoOwner.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubRepoOwner.swift
@@ -1,0 +1,13 @@
+//
+//  GitHubRepoOwner.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubRepoOwner: Decodable {
+    let avatarURL: String
+}

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubRepository.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 struct GitHubRepository: Decodable {
-    let fullName: String
-    let language: String
-    let stargazersCount: Int
-    let watchersCount: Int
-    let forksCount: Int
-    let openIssuesCount: Int
+    let fullName: String?
+    let language: String?
+    let stargazersCount: Int?
+    let watchersCount: Int?
+    let forksCount: Int?
+    let openIssuesCount: Int?
     let owner: GitHubRepoOwner
 
     enum CodingKeys: String, CodingKey {

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubRepository.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubRepository.swift
@@ -1,0 +1,29 @@
+//
+//  GitHubRepository.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubRepository: Decodable {
+    let fullName: String
+    let language: String
+    let stargazersCount: Int
+    let watchersCount: Int
+    let forksCount: Int
+    let openIssuesCount: Int
+    let owner: GitHubRepoOwner
+
+    enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+        case language
+        case stargazersCount = "stargazers_count"
+        case watchersCount = "wachers_count"
+        case forksCount = "forks_count"
+        case openIssuesCount = "open_issues_count"
+        case owner
+    }
+}

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubSearchRepositories.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubSearchRepositories.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct GitHubSearchRepositories: Decodable {
-    let items: [GitHubRepository]
+    let items: [GitHubRepository]?
 
     enum CodingKeys: String, CodingKey {
         case items

--- a/iOSEngineerCodeCheck/APIClient/Response/GitHubSearchRepositories.swift
+++ b/iOSEngineerCodeCheck/APIClient/Response/GitHubSearchRepositories.swift
@@ -1,0 +1,17 @@
+//
+//  GitHubSearchRepositories.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct GitHubSearchRepositories: Decodable {
+    let items: [GitHubRepository]
+
+    enum CodingKeys: String, CodingKey {
+        case items
+    }
+}

--- a/iOSEngineerCodeCheck/APIClient/Result.swift
+++ b/iOSEngineerCodeCheck/APIClient/Result.swift
@@ -1,0 +1,22 @@
+//
+//  Result.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+enum Result<T, Error: Swift.Error> {
+    case success(T)
+    case failure(Error)
+
+    init(value: T) {
+        self = .success(value)
+    }
+
+    init(error: Error) {
+        self = .failure(error)
+    }
+}

--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -82,8 +82,8 @@
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="oOe-O2-3RS">
-                                <rect key="frame" x="20" y="600" width="374" height="106"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="oOe-O2-3RS">
+                                <rect key="frame" x="20" y="597.5" width="374" height="106"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s3M-QO-Kom">
                                         <rect key="frame" x="0.0" y="0.0" width="66.5" height="17"/>
@@ -130,6 +130,7 @@
                             <constraint firstItem="4q1-pG-WSB" firstAttribute="top" secondItem="Iim-eb-8Ad" secondAttribute="bottom" constant="28" id="G2L-KM-330"/>
                             <constraint firstItem="4q1-pG-WSB" firstAttribute="centerX" secondItem="Iim-eb-8Ad" secondAttribute="centerX" id="Ght-Nb-HEu"/>
                             <constraint firstItem="srK-fe-i1b" firstAttribute="trailing" secondItem="Iim-eb-8Ad" secondAttribute="trailing" constant="20" id="IgU-EN-fM3"/>
+                            <constraint firstItem="oOe-O2-3RS" firstAttribute="top" secondItem="4q1-pG-WSB" secondAttribute="bottom" constant="20" id="b4q-Bz-Cda"/>
                             <constraint firstItem="oOe-O2-3RS" firstAttribute="width" secondItem="Iim-eb-8Ad" secondAttribute="width" id="dPu-j0-Myp"/>
                             <constraint firstItem="oOe-O2-3RS" firstAttribute="centerX" secondItem="4q1-pG-WSB" secondAttribute="centerX" id="kVV-YK-ePr"/>
                             <constraint firstItem="Iim-eb-8Ad" firstAttribute="centerY" secondItem="srK-fe-i1b" secondAttribute="centerY" multiplier="0.7" id="ruB-l0-4VM"/>

--- a/iOSEngineerCodeCheck/Configuration.swift
+++ b/iOSEngineerCodeCheck/Configuration.swift
@@ -1,0 +1,22 @@
+//
+//  Configuration.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Mika Urakawa on 2021/12/18.
+//  Copyright © 2021 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation
+
+struct Configuration {
+    static let shared = Configuration()
+
+    var apiHost = ""
+
+    private init() {
+        if let apiHost = Bundle.main.object(forInfoDictionaryKey: "APIHost") as? String,
+           !apiHost.isEmpty {
+            self.apiHost = apiHost
+        }
+    }
+}

--- a/iOSEngineerCodeCheck/Info.plist
+++ b/iOSEngineerCodeCheck/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>APIHost</key>
+	<string>$(API_HOST)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -17,7 +17,7 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet weak private var forksLabel: UILabel!
     @IBOutlet weak private var issuesLabel: UILabel!
 
-    var searchRepositoryVC: SearchRepositoryViewController!
+    weak var searchRepositoryVC: SearchRepositoryViewController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,7 +25,9 @@ class RepositoryDetailViewController: UIViewController {
     }
 
     private func setup() {
-        guard let selectedRowIndex = searchRepositoryVC.selectedRowindex else {
+        guard let searchRepositoryVC = searchRepositoryVC,
+              let selectedRowIndex = searchRepositoryVC.selectedRowindex
+        else {
             return
         }
         let repo = searchRepositoryVC.repositories[selectedRowIndex]
@@ -39,7 +41,9 @@ class RepositoryDetailViewController: UIViewController {
     }
 
     func getImage() {
-        guard let selectedRowIndex = searchRepositoryVC.selectedRowindex else {
+        guard let searchRepositoryVC = searchRepositoryVC,
+              let selectedRowIndex = searchRepositoryVC.selectedRowindex
+        else {
             return
         }
         let repo = searchRepositoryVC.repositories[selectedRowIndex]
@@ -51,8 +55,9 @@ class RepositoryDetailViewController: UIViewController {
         else {
             return
         }
-        URLSession.shared.dataTask(with: URL(string: imgURL)!) { (data, res, err) in
-            guard let data = data,
+        URLSession.shared.dataTask(with: URL(string: imgURL)!) { [weak self] (data, res, err) in
+            guard let self = self,
+                  let data = data,
                   let image = UIImage(data: data)
             else {
                 return

--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -24,6 +24,7 @@ class RepositoryDetailViewController: UIViewController {
         setup()
     }
 
+    /// 初期表示時のデータ準備
     private func setup() {
         guard let searchRepositoryVC = searchRepositoryVC,
               let selectedRowIndex = searchRepositoryVC.selectedRowindex
@@ -32,14 +33,15 @@ class RepositoryDetailViewController: UIViewController {
         }
         let repo = searchRepositoryVC.repositories[selectedRowIndex]
 
-        languageLabel.text = "Written in \(castToString(repo["language"]))"
-        starsLabel.text = "\(castToStringThoughInt(repo["stargazers_count"])) stars"
-        watchesLabel.text = "\(castToStringThoughInt(repo["wachers_count"])) watchers"
-        forksLabel.text = "\(castToStringThoughInt(repo["forks_count"])) forks"
-        issuesLabel.text = "\(castToStringThoughInt(repo["open_issues_count"])) open issues"
+        languageLabel.text = "Written in \(unwrap(repo.language))"
+        starsLabel.text = "\(unwrap(repo.stargazersCount)) stars"
+        watchesLabel.text = "\(unwrap(repo.watchersCount)) watchers"
+        forksLabel.text = "\(unwrap(repo.forksCount)) forks"
+        issuesLabel.text = "\(unwrap(repo.openIssuesCount)) open issues"
         getImage()
     }
 
+    /// リポジトリ所有者の画像取得
     func getImage() {
         guard let searchRepositoryVC = searchRepositoryVC,
               let selectedRowIndex = searchRepositoryVC.selectedRowindex
@@ -48,10 +50,9 @@ class RepositoryDetailViewController: UIViewController {
         }
         let repo = searchRepositoryVC.repositories[selectedRowIndex]
 
-        titleLabel.text = castToString(repo["full_name"])
+        titleLabel.text = repo.fullName
 
-        guard let owner = repo["owner"] as? [String: Any],
-              let imgURL = owner["avatar_url"] as? String
+        guard let imgURL = repo.owner.avatarURL
         else {
             return
         }
@@ -68,21 +69,19 @@ class RepositoryDetailViewController: UIViewController {
         }.resume()
     }
 
-    private func castToString(_ target: Any?) -> String {
-        guard let target = target,
-              let targetString = target as? String
-        else {
+    /// String?のアンラップ
+    private func unwrap(_ target: String?) -> String {
+        guard let target = target else {
             return "-"
         }
-        return targetString
+        return target
     }
 
-    private func castToStringThoughInt(_ target: Any?) -> String {
-        guard let target = target,
-              let targetInt = target as? Int
-        else {
-            return "-"
+    /// Int?のアンラップ
+    private func unwrap(_ target: Int?) -> Int {
+        guard let target = target else {
+            return 0
         }
-        return String(targetInt)
+        return target
     }
 }

--- a/iOSEngineerCodeCheck/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryViewController.swift
@@ -36,10 +36,14 @@ class SearchRepositoryViewController: UITableViewController {
 
         // GithubAPIでリポジトリのデータを取得
         let url = "https://api.github.com/search/repositories?q=\(searchKeyword)"
-        task = URLSession.shared.dataTask(with: URL(string: url)!) { (data, res, err) in
+        task = URLSession.shared.dataTask(with: URL(string: url)!) { [weak self] (data, res, err) in
+            guard let self = self,
+                  let data = data
+            else {
+                return
+            }
             do {
-                guard let data = data,
-                      let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                       let items = json["items"] as? [[String: Any]]
                 else {
                     return
@@ -57,8 +61,8 @@ class SearchRepositoryViewController: UITableViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "Detail" {
-            let dtl = segue.destination as? RepositoryDetailViewController
-            dtl?.searchRepositoryVC = self
+            let detailView = segue.destination as? RepositoryDetailViewController
+            detailView?.searchRepositoryVC = self
         }
     }
 

--- a/iOSEngineerCodeCheck/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/SearchRepositoryViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class SearchRepositoryViewController: UITableViewController {
     @IBOutlet weak private var searchBar: UISearchBar!
 
-    var repositories: [[String: Any]] = []
+    var repositories: [GitHubRepository] = []
     var task: URLSessionTask?
     var searchKeyword: String?
     var selectedRowindex: Int?
@@ -34,29 +34,25 @@ class SearchRepositoryViewController: UITableViewController {
             return
         }
 
-        // GithubAPIでリポジトリのデータを取得
-        let url = "https://api.github.com/search/repositories?q=\(searchKeyword)"
-        task = URLSession.shared.dataTask(with: URL(string: url)!) { [weak self] (data, res, err) in
-            guard let self = self,
-                  let data = data
-            else {
-                return
-            }
-            do {
-                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      let items = json["items"] as? [[String: Any]]
-                else {
+        // GithubAPIでリポジトリの一覧を取得
+        let client = GitHubClient()
+        let request = GitHubAPI.GitHubSearchRepo(keyword: searchKeyword)
+        client.send(request: request) { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case let .success(response):
+                guard let items = response.items else {
                     return
                 }
                 self.repositories = items
                 DispatchQueue.main.async {
                     self.tableView.reloadData()
                 }
-            } catch {
-                // TODO: エラー処理
+            case let .failure(error):
+                // TODO: エラーのアラートを表示
+                print(error)
             }
         }
-        task?.resume()
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -74,8 +70,8 @@ class SearchRepositoryViewController: UITableViewController {
 
         let cell = UITableViewCell()
         let repository = repositories[indexPath.row]
-        cell.textLabel?.text = castToString(repository["full_name"])
-        cell.detailTextLabel?.text = castToString(repository["language"])
+        cell.textLabel?.text = repository.fullName
+        cell.detailTextLabel?.text = repository.language
         cell.tag = indexPath.row
         return cell
     }
@@ -83,15 +79,6 @@ class SearchRepositoryViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         selectedRowindex = indexPath.row
         performSegue(withIdentifier: "Detail", sender: self)
-    }
-
-    private func castToString(_ target: Any?) -> String {
-        guard let target = target,
-              let targetString = target as? String
-        else {
-            return "-"
-        }
-        return targetString
     }
 }
 


### PR DESCRIPTION
## 対応内容

- #7 の対応
  - リポジトリ詳細画面のレイアウトエラー
  - メモリリーク対策
    - クロージャを使用する場合に、`[weak self]`を使用
    - ViewContoroller同士の強参照を弱参照に変更

## 関連リンク

- [GitHubのAPIドキュメント](https://docs.github.com/ja/rest/reference/search#search-repositories)

## その他

- APIと通信時または画像取得時に、以下のエラーがXcodeのログに表示される。
  - 調べたが原因不明のため、一旦Issue #14 にあげる
  - APIのレスポンス取得と表示、画像取得と表示は問題なく行われているため、このPRでは未対応とする

Closes #7 
