### PR TITLE
クリアボタンを押下した時にAPI通信を中断するよう修正

### DIFF
--- a/iOSEngineerCodeCheck/APIClient/GitHubClient.swift
+++ b/iOSEngineerCodeCheck/APIClient/GitHubClient.swift
@@ -14,6 +14,7 @@ class GitHubClient {
         let session = URLSession(configuration: configuration)
         return session
     }()
+    private var task: URLSessionTask?
 
     func send<Request: GitHubAPIRequest>(
         request: Request,
@@ -40,7 +41,13 @@ class GitHubClient {
                 )
             }
         }
+        self.task = task
 
         task.resume()
+    }
+
+    /// 処理中のタスクをキャンセルする
+    func cancel() {
+        task?.cancel()
     }
 }

--- a/iOSEngineerCodeCheck/Model/SearchRepositoryModel.swift
+++ b/iOSEngineerCodeCheck/Model/SearchRepositoryModel.swift
@@ -13,15 +13,17 @@ protocol SearchRepositoryModelInput {
         searchKeyword: String,
         completionHandler: @escaping ([GitHubRepository]?) -> Void
     )
+    func cancel()
 }
 
 final class SearchRepositoryModel: SearchRepositoryModelInput {
+    private var client = GitHubClient()
+
     /// リポジトリ一覧の取得
     func fetchRepositories(
         searchKeyword: String,
         completionHandler: @escaping ([GitHubRepository]?) -> Void
     ) {
-        let client = GitHubClient()
         let request = GitHubAPI.GitHubSearchRepo(keyword: searchKeyword)
         client.send(request: request) { result in
             switch result {
@@ -35,5 +37,10 @@ final class SearchRepositoryModel: SearchRepositoryModelInput {
                 completionHandler(nil)
             }
         }
+    }
+
+    /// 取得処理のキャンセル
+    func cancel() {
+        client.cancel()
     }
 }

--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -14,6 +14,7 @@ protocol SearchRepositoryPresenterInput {
     func repository(forRow row: Int) -> GitHubRepository?
     func didTapSearchButton(keyword: String?)
     func didTapSelectRow(at indexPath: IndexPath)
+    func didTapClearButton()
 }
 
 protocol SearchRepositoryPresenterOutput: AnyObject {
@@ -74,5 +75,10 @@ final class SearchRepositoryPresenter: SearchRepositoryPresenterInput {
             return
         }
         view.transitionToRepositoryDetail(repository: repository)
+    }
+
+    /// キャンセルボタンが押下された時の処理
+    func didTapClearButton() {
+        model.cancel()
     }
 }

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -13,7 +13,6 @@ class SearchRepositoryViewController: UIViewController {
     @IBOutlet weak private var searchBar: UISearchBar!
 
     var repositories: [GitHubRepository] = []
-    var task: URLSessionTask?
 
     private var presenter: SearchRepositoryPresenterInput!
     /// プレゼンタークラスをDIする
@@ -69,7 +68,9 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
     }
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        task?.cancel()
+        if searchText.isEmpty {
+            presenter.didTapClearButton()
+        }
     }
 }
 


### PR DESCRIPTION
## 対応内容

- API通信処理をViewControllerではなく、別クラスで実施するようにしたときに、キャンセル処理を実装することを忘れていたため、その対応を行なった

## 関連リンク

## その他

Closes #4 
Closes #5 
Closes #6
