### PR TITLE
Swiftlintの制約を修正

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,3 +9,6 @@ line_length:
 
 identifier_name:
   max_length: 60
+
+function_body_length:
+- 100


### PR DESCRIPTION
## 対応内容

- SwiftLintの`function_body_length`の制約を修正

## 関連リンク

## その他

Closes #
